### PR TITLE
Fix item and vault loading by name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,12 @@ jobs:
         run: printenv
       - name: Assert removed secrets
         run: ./tests/assert-env-unset.sh
-      - name: Load secret again
+      - name: Load secrets by vault and item titles
         uses: ./ # 1password/load-secrets-action@<version>
         env:
-          SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
-          SECRET_IN_SECTION: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/test-section/password
-          MULTILINE_SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/ghtz3jvcc6dqmzc53d3r3eskge/notesPlain
+          SECRET: op://acceptance-tests/test-secret/password
+          SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
+          MULTILINE_SECRET: op://acceptance-tests/multiline-secret/notesPlain
       - name: Print environment variables with masked secrets
         run: printenv
       - name: Assert test secret values again


### PR DESCRIPTION
More bash 😅, and also am aware that the amount of API calls could be reduced.
But a large chunk of this script should be removed soon anyway.

Also added a test for it.

Took the UUID determination logic from [here](https://github.com/1Password/onepassword-operator/blob/b574e394ad649d2cbf6f61192f00a1918cef8df3/pkg/onepassword/uuid.go#L7).