### PR TITLE
fix: Allow vaults and items with brackets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ for possible_ref in $(printenv | grep "=op://" | grep -v "^#"); do
 
   if [[ $(echo -n $(echo $vault | grep "^[a-z0-9]*$") | wc -c) -ne 26 ]]; then
     echo "Getting vault ID from vault name: $vault"
-    vault=$(curl -sSf "${curl_headers[@]}" "$OP_CONNECT_HOST/v1/vaults?filter=name%20eq%20%22$vault%22" | jq -r '.[0] | .id')
+    vault=$(curl -sSf "${curl_headers[@]}" --get --data-urlencode "filter=name eq \"$vault\"" "$OP_CONNECT_HOST/v1/vaults" | jq -r '.[0] | .id')
     if [ -z "$vault" ]; then
       echo "Could not find vault ID for vault: $vault"
       exit 1
@@ -83,7 +83,7 @@ for possible_ref in $(printenv | grep "=op://" | grep -v "^#"); do
 
   if [[ $(echo -n $(echo $item | grep "^[a-z0-9]*$") | wc -c) -ne 26 ]]; then
     echo "Getting item ID from vault $vault..."
-    item=$(curl -sSf "${curl_headers[@]}" "$OP_CONNECT_HOST/v1/vaults/$vault/items?filter=title%20eq%20%22$item%22" | jq -r '.[0] | .id')
+    item=$(curl -sSf "${curl_headers[@]}" --get --data-urlencode "filter=title eq \"$item\"" "$OP_CONNECT_HOST/v1/vaults/$vault/items" | jq -r '.[0] | .id')
     if [ -z "$item" ]; then
       echo "Could not find item ID for item: $item"
       exit 1


### PR DESCRIPTION
We are having issues when using this action because we have brackets in our vault and items names:

```
##[debug]/usr/bin/bash --noprofile --norc -e -o pipefail /home/runner/work/_temp/1afdd4f7-f7cf-41ca-a690-fbc13169b563.sh
Populating variable: SENTRY_AUTH_TOKEN
Getting vault ID from vault name: [STAGE] - Secrets
curl: (22) The requested URL returned error: 400 Bad Request
Could not find vault ID for vault: 
Error: Process completed with exit code 1.
```

So, this leverages on cURL feature to perform URL-encoding as described [here](https://stackoverflow.com/a/2027690).

I tested it with our own vaults and secrets, but it should cover other cases as well.