### PR TITLE
Improve the way input is processed to avoid command injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,9 @@ inputs:
     default: false
 runs:
   using: composite
-  steps: 
-    - run: |
-        export INPUT_UNSET_PREVIOUS=${{ inputs.unset-previous }}
+  steps:
+    - shell: bash
+      env:
+        INPUT_UNSET_PREVIOUS: ${{ inputs.unset-previous }}
+      run: |
         ${{ github.action_path }}/entrypoint.sh
-      shell: bash

--- a/configure/action.yml
+++ b/configure/action.yml
@@ -8,9 +8,10 @@ inputs:
     description: Token to authenticate to your 1Password Connect instance
 runs:
   using: composite
-  steps: 
-    - run: |
-        export INPUT_CONNECT_HOST=${{ inputs.connect-host }}
-        export INPUT_CONNECT_TOKEN=${{ inputs.connect-token }}
+  steps:
+    - shell: bash
+      env:
+        INPUT_CONNECT_HOST: ${{ inputs.connect-host }}
+        INPUT_CONNECT_TOKEN: ${{ inputs.connect-token }}
+      run: |
         ${{ github.action_path }}/entrypoint.sh
-      shell: bash


### PR DESCRIPTION
All the input for this action is now properly handled (i.e. escaped) to avoid command injection.
This fix is based on this article by the GitHub Security Lab: [Keeping your GitHub Actions and workflows secure Part 2: Untrusted input](https://securitylab.github.com/research/github-actions-untrusted-input/)