### PR TITLE
Ensure that the action is backwards-compatible

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,8 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
+        with:
+          export-env: false
         env:
           SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
           SECRET_IN_SECTION: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/Section_tco6nsqycj6jcbyx63h5isxcny/doxu3mhkozcznnk5vjrkpdqayy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,13 @@ jobs:
       - name: Configure 1Password Connect
         uses: ./configure # 1password/load-secrets-action/configure@<version>
         with:
-          connect-host: http://localhost:8080
+          connect-host: localhost:8080
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
+        with:
+          export-env: false
         env:
           SECRET: op://acceptance-tests/test-secret/password
           SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
@@ -48,8 +50,6 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
-        with:
-          export-env: true
         env:
           SECRET: op://acceptance-tests/test-secret/password
           SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
@@ -97,6 +97,8 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
+        with:
+          export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://acceptance-tests/test-secret/password
@@ -115,8 +117,6 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
-        with:
-          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://acceptance-tests/test-secret/password
@@ -131,6 +131,8 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
+        with:
+          export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
@@ -149,6 +151,8 @@ jobs:
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
+        with:
+          export-env: false
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://acceptance-tests/test-secret/password

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ jobs:
       - name: Load secret
         id: op-load-secret
         uses: 1password/load-secrets-action@v1
+        with:
+          export-env: false
         env:
           OP_CONNECT_HOST: <Your Connect instance URL>
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
@@ -77,6 +79,8 @@ jobs:
       - name: Load Docker credentials
         id: load-docker-credentials
         uses: 1password/load-secrets-action@v1
+        with:
+          export-env: false
         env:
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
           DOCKERHUB_USERNAME: op://app-cicd/docker/username
@@ -111,9 +115,6 @@ jobs:
 
       - name: Load secret
         uses: 1password/load-secrets-action@v1
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
         env:
           OP_CONNECT_HOST: <Your Connect instance URL>
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
@@ -147,9 +148,6 @@ jobs:
 
       - name: Load Docker credentials
         uses: 1password/load-secrets-action@v1
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
         env:
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
           DOCKERHUB_USERNAME: op://app-cicd/docker/username
@@ -173,8 +171,6 @@ jobs:
       - name: Load AWS credentials
         uses: 1password/load-secrets-action@v1
         with:
-          # Export loaded secrets as environment variables
-          export-env: true
           # Remove local copies of the Docker credentials, which are not needed anymore
           unset-previous: true
         env:
@@ -194,7 +190,7 @@ jobs:
 
 | Name             | Default | Description                                                                        |
 | ---------------- | ------- | ---------------------------------------------------------------------------------- |
-| `export-env`     | `false` | Export the loaded secrets as environment variables                                 |
+| `export-env`     | `true`  | Export the loaded secrets as environment variables                                 |
 | `unset-previous` | `false` | Whether to unset environment variables populated by 1Password in earlier job steps |
 
 ## Secrets Reference Syntax

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ jobs:
 
       - name: Load secret
         uses: 1password/load-secrets-action@v1
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
         env:
           OP_CONNECT_HOST: <Your Connect instance URL>
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
@@ -148,6 +151,9 @@ jobs:
 
       - name: Load Docker credentials
         uses: 1password/load-secrets-action@v1
+        with:
+          # Export loaded secrets as environment variables
+          export-env: true
         env:
           OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
           DOCKERHUB_USERNAME: op://app-cicd/docker/username
@@ -171,6 +177,8 @@ jobs:
       - name: Load AWS credentials
         uses: 1password/load-secrets-action@v1
         with:
+          # Export loaded secrets as environment variables
+          export-env: true
           # Remove local copies of the Docker credentials, which are not needed anymore
           unset-previous: true
         env:

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: false
   export-env:
     description: Export the secrets as environment variables
-    default: false
+    default: true
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,9 +14,9 @@ auth_type=$CONNECT
 managed_variables_var="OP_MANAGED_VARIABLES"
 IFS=','
 
-# if [[ "$OP_CONNECT_HOST" != "http://"* ]] || [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
-#   export OP_CONNECT_HOST="http://"$OP_CONNECT_HOST
-# fi
+if [[ "$OP_CONNECT_HOST" != "http://"* ]] && [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
+  export OP_CONNECT_HOST="http://"$OP_CONNECT_HOST
+fi
 
 # Unset all secrets managed by 1Password if `unset-previous` is set.
 unset_prev_secrets() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,9 +14,9 @@ auth_type=$CONNECT
 managed_variables_var="OP_MANAGED_VARIABLES"
 IFS=','
 
-if [[ "$OP_CONNECT_HOST" != "http://"* ]] || [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
-  export OP_CONNECT_HOST=HTTP://$OP_CONNECT_HOST
-fi
+# if [[ "$OP_CONNECT_HOST" != "http://"* ]] || [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
+#   export OP_CONNECT_HOST="http://"$OP_CONNECT_HOST
+# fi
 
 # Unset all secrets managed by 1Password if `unset-previous` is set.
 unset_prev_secrets() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,10 @@ auth_type=$CONNECT
 managed_variables_var="OP_MANAGED_VARIABLES"
 IFS=','
 
+if [[ "$OP_CONNECT_HOST" != "HTTP://"* ]] || [[ "$OP_CONNECT_HOST" != "HTTPS://"* ]]; then
+  export OP_CONNECT_HOST=HTTP://$OP_CONNECT_HOST
+fi
+
 # Unset all secrets managed by 1Password if `unset-previous` is set.
 unset_prev_secrets() {
   if [ "$INPUT_UNSET_PREVIOUS" == "true" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ auth_type=$CONNECT
 managed_variables_var="OP_MANAGED_VARIABLES"
 IFS=','
 
-if [[ "$OP_CONNECT_HOST" != "HTTP://"* ]] || [[ "$OP_CONNECT_HOST" != "HTTPS://"* ]]; then
+if [[ "$OP_CONNECT_HOST" != "http://"* ]] || [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
   export OP_CONNECT_HOST=HTTP://$OP_CONNECT_HOST
 fi
 


### PR DESCRIPTION
This PR brings 2 changes that ensure that the GitHub Action is backwards compatible:
- Append `http://` if the prefix is not provided in the `OP_CONNECT_HOST` (this is caused by the fact that `curl` [guesses the protocol if not provided](https://linux.die.net/man/1/curl), which we missed when switching to using the 1Password CLI as the backend of the action)
- Set the default of `export-env` to `true`, since that was the default behavior of the action until we added the possibility to export secrets as step's output.

Also, the documentation is adjusted to reflect these changes.