### PR TITLE
Use environment file to manage output instead of `set-output`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,7 @@ populating_secret() {
     # Prepare the secret_value to be outputed properly (especially multiline secrets)
     secret_value=$(echo "$secret_value" | awk -v ORS='%0A' '1')
 
-    echo "::set-output name=$env_var::$secret_value"
+    echo "$env_var=$secret_value" >> "$GITHUB_OUTPUT"
   fi
 
   managed_variables+=("$env_var")


### PR DESCRIPTION
`set-output` & `save-state` are now deprecated

resolves 1Password/load-secrets-action#27