### PR TITLE
Revert "Use environment file to manage output instead of `set-output`"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,7 @@ populating_secret() {
     # Prepare the secret_value to be outputed properly (especially multiline secrets)
     secret_value=$(echo "$secret_value" | awk -v ORS='%0A' '1')
 
-    echo "$env_var=$secret_value" >> "$GITHUB_OUTPUT"
+    echo "::set-output name=$env_var::$secret_value"
   fi
 
   managed_variables+=("$env_var")


### PR DESCRIPTION
Reverts 1Password/load-secrets-action#29

It seems that the tests fail when using the new syntax. Reverting this for now and will further investigate how to adjust the syntax so that the tests work again.