### PR TITLE
Draft: Migrate action to Typescript

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,33 +1,5 @@
 #!/bin/bash
-# shellcheck disable=SC2046,SC2001,SC2086
 set -e
-
-# Pass User-Agent Inforomation to the 1Password CLI
-export OP_INTEGRATION_NAME="1Password GitHub Action"
-export OP_INTEGRATION_ID="GHA"
-export OP_INTEGRATION_BUILDNUMBER="1010001"
-
-managed_variables_var="OP_MANAGED_VARIABLES"
-IFS=','
-
-# Unset all secrets managed by 1Password if `unset-previous` is set.
-unset_prev_secrets() {
-  if [ "$INPUT_UNSET_PREVIOUS" == "true" ]; then
-    echo "Unsetting previous values..."
-
-    # Find environment variables that are managed by 1Password.
-    for env_var in "${managed_variables[@]}"; do
-      echo "Unsetting $env_var"
-      unset $env_var
-
-      echo "$env_var=" >> $GITHUB_ENV
-
-      # Keep the masks, just in case.
-    done
-
-    managed_variables=()
-  fi
-}
 
 # Install op-cli
 install_op_cli() {
@@ -47,6 +19,7 @@ install_op_cli() {
     tar -xvf temp-pkg/op.pkg/Payload -C "$OP_INSTALL_DIR"
     rm -rf temp-pkg && rm op.pkg
   fi
+  echo "$OP_INSTALL_DIR" >> "$GITHUB_PATH"
 }
 
 # Uninstall op-cli
@@ -56,72 +29,4 @@ uninstall_op_cli() {
   fi
 }
 
-populating_secret() {
-  ref=$(printenv $1)
-
-  echo "Populating variable: $1"
-  secret_value=$("${OP_INSTALL_DIR}/op" read "$ref")
-
-  if [ -z "$secret_value" ]; then
-    echo "Could not find or access secret $ref"
-    exit 1
-  fi
-
-  # Register a mask for the secret to prevent accidental log exposure.
-  # To support multiline secrets, escape percent signs and add a mask per line.
-  escaped_mask_value=$(echo "$secret_value" | sed -e 's/%/%25/g')
-  IFS=$'\n'
-  for line in $escaped_mask_value; do
-    if [ "${#line}" -lt 3 ]; then
-      # To avoid false positives and unreadable logs, omit mask for lines that are too short.
-      continue
-    fi
-    echo "::add-mask::$line"
-  done
-  unset IFS
-
-  if [ "$INPUT_EXPORT_ENV" == "true" ]; then
-    # To support multiline secrets, we'll use the heredoc syntax to populate the environment variables.
-    # As the heredoc identifier, we'll use a randomly generated 64-character string,
-    # so that collisions are practically impossible.
-    random_heredoc_identifier=$(openssl rand -hex 32)
-
-    {
-      # Populate env var, using heredoc syntax with generated identifier
-      echo "$env_var<<${random_heredoc_identifier}"
-      echo "$secret_value"
-      echo "${random_heredoc_identifier}"
-    } >> $GITHUB_ENV
-    echo "GITHUB_ENV: $(cat $GITHUB_ENV)"
-
-  else
-    # Prepare the secret_value to be outputed properly (especially multiline secrets)
-    secret_value=$(echo "$secret_value" | awk -v ORS='%0A' '1')
-
-    echo "::set-output name=$env_var::$secret_value"
-  fi
-
-  managed_variables+=("$env_var")
-}
-
-# Load environment variables using op cli. Iterate over them to find 1Password references, load the secret values,
-# and make them available as environment variables in the next steps.
-extract_secrets() {
-  IFS=$'\n'
-  for env_var in $("${OP_INSTALL_DIR}/op" env ls); do
-    populating_secret $env_var
-  done
-}
-
-read -r -a managed_variables <<< "$(printenv $managed_variables_var)"
-
-unset_prev_secrets
 install_op_cli
-extract_secrets
-uninstall_op_cli
-
-unset IFS
-# Add extra env var that lists which secrets are managed by 1Password so that in a later step
-# these can be unset again.
-managed_variables_str=$(IFS=','; echo "${managed_variables[*]}")
-echo "$managed_variables_var=$managed_variables_str" >> $GITHUB_ENV

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,16 +7,8 @@ export OP_INTEGRATION_NAME="1Password GitHub Action"
 export OP_INTEGRATION_ID="GHA"
 export OP_INTEGRATION_BUILDNUMBER="1010001"
 
-readonly CONNECT="CONNECT"
-readonly SERVICE_ACCOUNT="SERVICE_ACCOUNT"
-
-auth_type=$CONNECT
 managed_variables_var="OP_MANAGED_VARIABLES"
 IFS=','
-
-if [[ "$OP_CONNECT_HOST" != "http://"* ]] && [[ "$OP_CONNECT_HOST" != "https://"* ]]; then
-  export OP_CONNECT_HOST="http://"$OP_CONNECT_HOST
-fi
 
 # Unset all secrets managed by 1Password if `unset-previous` is set.
 unset_prev_secrets() {
@@ -122,17 +114,6 @@ extract_secrets() {
 }
 
 read -r -a managed_variables <<< "$(printenv $managed_variables_var)"
-
-if [ -z "$OP_CONNECT_TOKEN" ] || [ -z "$OP_CONNECT_HOST" ]; then
-  if [ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
-    echo "(\$OP_CONNECT_TOKEN and \$OP_CONNECT_HOST) or \$OP_SERVICE_ACCOUNT_TOKEN must be set"
-    exit 1
-  fi
-
-  auth_type=$SERVICE_ACCOUNT
-fi
-
-printf "Authenticated with %s \n" $auth_type
 
 unset_prev_secrets
 install_op_cli

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
+				"@1password/op-js": "^0.1.8",
 				"@actions/core": "^1.10.0",
 				"@actions/exec": "^1.1.1"
 			},
@@ -55,6 +56,15 @@
 			"peerDependencies": {
 				"postcss": "^8.3.3",
 				"typescript": ">=4.0.3"
+			}
+		},
+		"node_modules/@1password/op-js": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@1password/op-js/-/op-js-0.1.8.tgz",
+			"integrity": "sha512-36Y4TXI0tBwDe6672CHhHvZErf1mgH0/AVt0woCZByOBM5PPUq/CSxAHKilKZrK8vpsTBA68MxV8q2RUExzfsg==",
+			"dependencies": {
+				"lookpath": "^1.2.2",
+				"semver": "^7.3.6"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -5598,6 +5608,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lookpath": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+			"integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==",
+			"bin": {
+				"lookpath": "bin/lookpath.js"
+			},
+			"engines": {
+				"npm": ">=6.13.4"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6790,7 +6811,6 @@
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
 			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -6805,7 +6825,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -6816,8 +6835,7 @@
 		"node_modules/semver/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -7837,6 +7855,15 @@
 				"prettier": "2.5.1",
 				"stylelint": "^14.0.0",
 				"stylelint-scss": "^4.0.0"
+			}
+		},
+		"@1password/op-js": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@1password/op-js/-/op-js-0.1.8.tgz",
+			"integrity": "sha512-36Y4TXI0tBwDe6672CHhHvZErf1mgH0/AVt0woCZByOBM5PPUq/CSxAHKilKZrK8vpsTBA68MxV8q2RUExzfsg==",
+			"requires": {
+				"lookpath": "^1.2.2",
+				"semver": "^7.3.6"
 			}
 		},
 		"@actions/core": {
@@ -11943,6 +11970,11 @@
 				}
 			}
 		},
+		"lookpath": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+			"integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q=="
+		},
 		"loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -12784,7 +12816,6 @@
 			"version": "7.3.8",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
 			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
 			},
@@ -12793,7 +12824,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-					"dev": true,
 					"requires": {
 						"yallist": "^4.0.0"
 					}
@@ -12801,8 +12831,7 @@
 				"yallist": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-					"dev": true
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	},
 	"homepage": "https://github.com/1Password/load-secrets-action#readme",
 	"dependencies": {
+		"@1password/op-js": "^0.1.8",
 		"@actions/core": "^1.10.0",
 		"@actions/exec": "^1.1.1"
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,16 +5,13 @@ import * as exec from "@actions/exec";
 
 const run = async () => {
 	try {
-		const currentFile = url.fileURLToPath(import.meta.url);
-		const currentDir = path.dirname(currentFile);
-		const parentDir = path.resolve(currentDir, "..");
 
 		// Get action inputs
 		process.env.INPUT_UNSET_PREVIOUS = core.getInput("unset-previous");
 		process.env.INPUT_EXPORT_ENV = core.getInput("export-env");
 
 		// Execute bash script
-		await exec.exec(`sh -c "` + parentDir + `/entrypoint.sh"`);
+		await executeScript();
 	} catch (error) {
 		// It's possible for the Error constructor to be modified to be anything
 		// in JavaScript, so the following code accounts for this possibility.
@@ -28,5 +25,14 @@ const run = async () => {
 		core.setFailed(message);
 	}
 };
+
+const executeScript = async (): Promise<void> => {
+	const currentFile = url.fileURLToPath(import.meta.url);
+	const currentDir = path.dirname(currentFile);
+	const parentDir = path.resolve(currentDir, "..");
+
+	// Execute bash script
+	await exec.exec(`sh -c "` + parentDir + `/entrypoint.sh"`);
+}
 
 void run();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,14 @@ import url from "url";
 import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 
+const envConnectHost = "OP_CONNECT_HOST";
+const envConnectToken = "OP_CONNECT_TOKEN";
+const envServiceAccountToken = "OP_SERVICE_ACCOUNT_TOKEN";
+
 const run = async () => {
 	try {
+		// Validate that a proper authentication configuration is set for the CLI
+		validateAuth();
 
 		// Get action inputs
 		process.env.INPUT_UNSET_PREVIOUS = core.getInput("unset-previous");
@@ -26,6 +32,30 @@ const run = async () => {
 	}
 };
 
+const validateAuth = () => {
+	let authType = "Connect";
+	if (!process.env[envConnectHost] || !process.env[envConnectToken]) {
+		if (!process.env[envServiceAccountToken]) {
+			throw new Error(
+				`(${envConnectHost} and ${envConnectToken}) or ${envServiceAccountToken} must be set`,
+			);
+		}
+		authType = "Service account";
+	}
+
+	// Adjust Connect host to have a protocol
+	if (
+		process.env[envConnectHost] &&
+		/* eslint-disable no-restricted-syntax */
+		(!process.env[envConnectHost]?.startsWith("http://") ||
+			!process.env[envConnectHost].startsWith("https://"))
+	) {
+		process.env[envConnectHost] = `http://${process.env[envConnectHost]}`;
+	}
+
+	core.debug(`Authenticated with ${authType}.`);
+};
+
 const executeScript = async (): Promise<void> => {
 	const currentFile = url.fileURLToPath(import.meta.url);
 	const currentDir = path.dirname(currentFile);
@@ -33,6 +63,6 @@ const executeScript = async (): Promise<void> => {
 
 	// Execute bash script
 	await exec.exec(`sh -c "` + parentDir + `/entrypoint.sh"`);
-}
+};
 
 void run();


### PR DESCRIPTION
This PR migrates most of the functionality of the GitHub Action to Typescript.

## Key elements used in the migration
| Element | Explanation |
|:---------|:-----------|
| [`op-js`](https://github.com/1Password/op-js) | Typescript package that wraps 1Password CLI commands. It enables us to easily work with the output returned by the 1Password CLI. |
| [`core.setOutput`](https://github.com/actions/toolkit/tree/master/packages/core#inputsoutputs) | Make the secret available as a step's output (works with multiline secrets as well). |
| [`core.exportVariable`](https://github.com/actions/toolkit/tree/master/packages/core#exporting-variables) | Make the secret available as an environment variable (works with multiline secrets as well). |
| [`core.setSecret`](https://github.com/actions/toolkit/tree/master/packages/core#setting-a-secret) | Ensures the secret is masked in logs. |

## Migration process
The commits should show an overview of the steps of the migration. I will present here the details of the main migration step highlighted in [`6c9a28c`](https://github.com/1Password/load-secrets-action/commit/6c9a28c6b2e4fc30bb9c9302a7878a89bf8bbd47):
| Function from `entrypoint.sh` | Functionality in `index.ts` |
|--------|-------|
| auth validation (no dedicated function) | `validateAuth` |
| `install_cli` | `installCLI` |
| `extract_secrets`. `populating_secret` | `extractSecrets` |

Note: `installCLI` in `index.tx` *only* executes the shell script that will perform the CLI installation. No real migration has been performed for this part of the action.