### PR TITLE
Improve pipelines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,20 +46,31 @@ jobs:
           SECRET_IN_SECTION: ${{ steps.load_secrets.outputs.SECRET_IN_SECTION }}
           MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
         run: ./tests/assert-env-set.sh
-  use-connect-with-export-env:
+  test-with-export-env:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
+        auth: [ connect, service-account ]
+        exclude:
+          - os: macos-latest
+            auth: connect
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
+        if: ${{ matrix.auth == 'connect' }}
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
           docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+      - name: Configure Service account
+        if: ${{ matrix.auth == 'service-account' }}
+        uses: ./configure
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Configure 1Password Connect
+        if: ${{ matrix.auth == 'connect' }}
         uses: ./configure # 1password/load-secrets-action/configure@<version>
         with:
           connect-host: http://localhost:8080
@@ -79,20 +90,31 @@ jobs:
           unset-previous: true
       - name: Assert removed secrets
         run: ./tests/assert-env-unset.sh
-  use-connect-with-references-with-id:
+  test-references-with-ids:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
+        auth: [ connect, service-account ]
+        exclude:
+          - os: macos-latest
+            auth: connect
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
+        if: ${{ matrix.auth == 'connect' }}
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
           docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+      - name: Configure Service account
+        if: ${{ matrix.auth == 'service-account' }}
+        uses: ./configure
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Configure 1Password Connect
+        if: ${{ matrix.auth == 'connect' }}
         uses: ./configure # 1password/load-secrets-action/configure@<version>
         with:
           connect-host: http://localhost:8080
@@ -103,69 +125,6 @@ jobs:
         with:
           export-env: false
         env:
-          SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
-          SECRET_IN_SECTION: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/Section_tco6nsqycj6jcbyx63h5isxcny/doxu3mhkozcznnk5vjrkpdqayy
-          MULTILINE_SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/ghtz3jvcc6dqmzc53d3r3eskge/notesPlain
-      - name: Assert test secret values
-        env:
-          SECRET: ${{ steps.load_secrets.outputs.SECRET }}
-          SECRET_IN_SECTION: ${{ steps.load_secrets.outputs.SECRET_IN_SECTION }}
-          MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
-        run: ./tests/assert-env-set.sh
-  use-service-account-without-export-env:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Load secrets
-        id: load_secrets
-        uses: ./ # 1password/load-secrets-action@<version>
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SECRET: op://acceptance-tests/test-secret/password
-          SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
-          MULTILINE_SECRET: op://acceptance-tests/multiline-secret/notesPlain
-      - name: Assert test secret values
-        env:
-          SECRET: ${{ steps.load_secrets.outputs.SECRET }}
-          SECRET_IN_SECTION: ${{ steps.load_secrets.outputs.SECRET_IN_SECTION }}
-          MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
-        run: ./tests/assert-env-set.sh
-  use-service-account-with-export-env:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Load secrets
-        id: load_secrets
-        uses: ./ # 1password/load-secrets-action@<version>
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SECRET: op://acceptance-tests/test-secret/password
-          SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
-          MULTILINE_SECRET: op://acceptance-tests/multiline-secret/notesPlain
-      - name: Assert test secret values
-        run: ./tests/assert-env-set.sh
-  use-service-account-with-references-with-id:
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Load secrets
-        id: load_secrets
-        uses: ./ # 1password/load-secrets-action@<version>
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
           SECRET_IN_SECTION: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/Section_tco6nsqycj6jcbyx63h5isxcny/doxu3mhkozcznnk5vjrkpdqayy
           MULTILINE_SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/ghtz3jvcc6dqmzc53d3r3eskge/notesPlain

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,20 +2,28 @@ on: push
 name: Run acceptance tests
 
 jobs:
-  use-connect-without-export-env:
+  test-with-output-secrets:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        auth: [ connnect, service-account ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
+        if: ${{ matrix.auth == 'connect' }}
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
           docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+      - name: Configure Service account
+        if: ${{ matrix.auth == 'service-account' }}
+        uses: ./configure
+        with:
+          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
       - name: Configure 1Password Connect
+        if: ${{ matrix.auth == 'connect' }}
         uses: ./configure # 1password/load-secrets-action/configure@<version>
         with:
           connect-host: localhost:8080

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   use-connect-without-export-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
@@ -35,7 +35,7 @@ jobs:
   use-connect-with-export-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
@@ -65,7 +65,7 @@ jobs:
   use-connect-with-references-with-id:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
         env:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
@@ -95,7 +95,7 @@ jobs:
   use-service-account-without-export-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
@@ -115,7 +115,7 @@ jobs:
   use-service-account-with-export-env:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
@@ -129,7 +129,7 @@ jobs:
   use-service-account-with-references-with-id:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>
@@ -149,7 +149,7 @@ jobs:
   run-on-macos-12:
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Load secrets
         id: load_secrets
         uses: ./ # 1password/load-secrets-action@<version>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        auth: [ connnect, service-account ]
+        auth: [ connect, service-account ]
+        exclude:
+          - os: macos-latest
+            auth: connect
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +49,7 @@ jobs:
   use-connect-with-export-env:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +82,7 @@ jobs:
   use-connect-with-references-with-id:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,10 @@ name: Run acceptance tests
 
 jobs:
   use-connect-without-export-env:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
@@ -33,7 +36,10 @@ jobs:
           MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
         run: ./tests/assert-env-set.sh
   use-connect-with-export-env:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
@@ -63,7 +69,10 @@ jobs:
       - name: Assert removed secrets
         run: ./tests/assert-env-unset.sh
   use-connect-with-references-with-id:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Launch 1Password Connect instance
@@ -93,7 +102,10 @@ jobs:
           MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
         run: ./tests/assert-env-set.sh
   use-service-account-without-export-env:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Load secrets
@@ -113,7 +125,10 @@ jobs:
           MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
         run: ./tests/assert-env-set.sh
   use-service-account-with-export-env:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Load secrets
@@ -127,7 +142,10 @@ jobs:
       - name: Assert test secret values
         run: ./tests/assert-env-set.sh
   use-service-account-with-references-with-id:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Load secrets
@@ -140,26 +158,6 @@ jobs:
           SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
           SECRET_IN_SECTION: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/Section_tco6nsqycj6jcbyx63h5isxcny/doxu3mhkozcznnk5vjrkpdqayy
           MULTILINE_SECRET: op://v5pz6venw4roosmkzdq2nhpv6u/ghtz3jvcc6dqmzc53d3r3eskge/notesPlain
-      - name: Assert test secret values
-        env:
-          SECRET: ${{ steps.load_secrets.outputs.SECRET }}
-          SECRET_IN_SECTION: ${{ steps.load_secrets.outputs.SECRET_IN_SECTION }}
-          MULTILINE_SECRET: ${{ steps.load_secrets.outputs.MULTILINE_SECRET }}
-        run: ./tests/assert-env-set.sh
-  run-on-macos-12:
-    runs-on: macos-12
-    steps:
-      - uses: actions/checkout@v3
-      - name: Load secrets
-        id: load_secrets
-        uses: ./ # 1password/load-secrets-action@<version>
-        with:
-          export-env: false
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SECRET: op://acceptance-tests/test-secret/password
-          SECRET_IN_SECTION: op://acceptance-tests/test-secret/test-section/password
-          MULTILINE_SECRET: op://acceptance-tests/multiline-secret/notesPlain
       - name: Assert test secret values
         env:
           SECRET: ${{ steps.load_secrets.outputs.SECRET }}


### PR DESCRIPTION
This PR adds the following improvements:
- Use `actions/checkout@v3` since `v2` uses Node 12, which is deprecated.
- Use job matrix to enhance the testing matrices we cover.
  Previously we were having 7 tests: 3 for Connect on Linux, 3 for service accounts on Linux, 1 for service accounts on MacOS. Each test had its own job, which lead to a lot of duplicated code.
  With matrices, we've managed to do the following:
  - Reduce the number of jobs written in the YAML file from 7 to 3 main cases:
    - Test with secrets provided as a step output.
    - Test with secrets provided as exported environment variables.
    - Test with secret references that have IDs.
  - Increase the number of tests from 7 to 9. Each of the 3 main test cases now cover the following 3 scenarios:
    - 2 tests for service account: one on Linux, one on MacOS
    - 1 test for Connect on Linux

**Note:** The lack of tests with Connect on MacOS runners is caused by the fact that `docker-compose` doesn't exist on these runners. More investigation is needed to achieve this. 🤔 