### PR TITLE
Remove 'BETA' references from Service Accounts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,8 +5,8 @@ jobs:
   test-with-output-secrets:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        auth: [ connect, service-account ]
+        os: [ubuntu-latest, macos-latest]
+        auth: [connect, service-account]
         exclude:
           - os: macos-latest
             auth: connect
@@ -49,8 +49,8 @@ jobs:
   test-with-export-env:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        auth: [ connect, service-account ]
+        os: [ubuntu-latest, macos-latest]
+        auth: [connect, service-account]
         exclude:
           - os: macos-latest
             auth: connect
@@ -93,8 +93,8 @@ jobs:
   test-references-with-ids:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
-        auth: [ connect, service-account ]
+        os: [ubuntu-latest, macos-latest]
+        auth: [connect, service-account]
         exclude:
           - os: macos-latest
             auth: connect

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Load Secrets from 1Password - GitHub Action
 
-This action loads secrets from 1Password into GitHub Actions using [1Password Connect](https://developer.1password.com/docs/connect) or a [Service Account <sup>[BETA]</sup>](https://developer.1password.com/docs/service-accounts).
+This action loads secrets from 1Password into GitHub Actions using [1Password Connect](https://developer.1password.com/docs/connect) or a [Service Account](https://developer.1password.com/docs/service-accounts).
 
 Specify in your workflow YAML file which secrets from 1Password should be loaded into your job, and the action will make them available as environment variables for the next steps.
 
@@ -58,7 +58,7 @@ jobs:
 ```
 
 <details>
-<summary><b>Usage example with Service Accounts <sup>BETA</sup></b></summary>
+<summary><b>Usage example with Service Accounts</b></summary>
 
 ```yml
 on: push
@@ -131,7 +131,7 @@ jobs:
 </details>
 
 <details>
-<summary><b>Longer usage example with Service Accounts <sup>BETA</sup></b></summary>
+<summary><b>Longer usage example with Service Accounts</b></summary>
 
 ```yml
 on: push
@@ -201,7 +201,7 @@ jobs:
 ```
 
 <details>
-<summary><b>Usage example with Service Accounts <sup>BETA</sup></b></summary>
+<summary><b>Usage example with Service Accounts</b></summary>
 
 ```yml
 on: push
@@ -295,7 +295,7 @@ jobs:
 </details>
 
 <details>
-<summary><b>Longer usage example with Service Accounts <sup>BETA</sup></b></summary>
+<summary><b>Longer usage example with Service Accounts</b></summary>
 
 ```yml
 on: push
@@ -389,7 +389,7 @@ So if one of these values accidentally gets printed, it'll get replaced with `**
 To use the action with Connect, you need to have a [1Password Connect](https://support.1password.com/secrets-automation/#step-1-set-up-a-secrets-automation-workflow) instance deployed somewhere.
 To configure the action with your Connect host and token, set the `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` environment variables.
 
-To configure the action with your service account token <sup>BETA</sup>, set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable.
+To configure the action with your service account token, set the `OP_SERVICE_ACCOUNT_TOKEN` environment variable.
 
 If you're using the `load-secrets` action more than once in a single job, you can use the `configure` action to avoid duplicate configuration:
 


### PR DESCRIPTION
- This PR removes the `BETA` references from mentions of Service Accounts in the `README.md` file.
- It can be merged after Service Accounts have exited beta and entered general availability (GA).
- It also includes a few auto-formatting fixes (courtesy of Prettier) in the `.github/workflows/test.yml` file; these are just ` ` space characters that were removed as defined by our code formatting rules.