### PR TITLE
Improve the shell script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,25 +104,27 @@ populating_secret() {
   done
   unset IFS
 
-  if [ "$INPUT_EXPORT_ENV" == "true" ]; then
-    # To support multiline secrets, we'll use the heredoc syntax to populate the environment variables.
-    # As the heredoc identifier, we'll use a randomly generated 64-character string,
-    # so that collisions are practically impossible.
-    random_heredoc_identifier=$(openssl rand -hex 32)
+  # To support multiline secrets, we'll use the heredoc syntax to populate the environment variables.
+  # As the heredoc identifier, we'll use a randomly generated 64-character string,
+  # so that collisions are practically impossible.
+  delimiter="$(openssl rand -hex 32)"
 
+  if [ "$INPUT_EXPORT_ENV" == "true" ]; then
     {
       # Populate env var, using heredoc syntax with generated identifier
-      echo "$env_var<<${random_heredoc_identifier}"
+      echo "$env_var<<${delimiter}"
       echo "$secret_value"
-      echo "${random_heredoc_identifier}"
+      echo "${delimiter}"
     } >> $GITHUB_ENV
     echo "GITHUB_ENV: $(cat $GITHUB_ENV)"
 
   else
-    # Prepare the secret_value to be outputed properly (especially multiline secrets)
-    secret_value=$(echo "$secret_value" | awk -v ORS='%0A' '1')
-
-    echo "::set-output name=$env_var::$secret_value"
+    {
+      # Populate env var, using heredoc syntax with generated identifier
+      echo "$env_var<<${delimiter}"
+      echo "$secret_value"
+      echo "${delimiter}"
+    } >> $GITHUB_OUTPUT
   fi
 
   managed_variables+=("$env_var")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,7 @@ install_op_cli() {
       ARCH="arm64"
     fi
 
-    if [[ "$ARCH" != "386" ]] && [[ "$ARCH" == "amd64" ]] && [[ "$ARCH" == "arm" ]] && [[ "$ARCH" == "arm64" ]]; then
+    if [[ "$ARCH" != "386" ]] && [[ "$ARCH" != "amd64" ]] && [[ "$ARCH" != "arm" ]] && [[ "$ARCH" != "arm64" ]]; then
       echo "Unsupported architecture for the 1Password CLI: $ARCH."
       exit 1
     fi
@@ -114,6 +114,7 @@ populating_secret() {
   # To support multiline secrets, we'll use the heredoc syntax to populate the environment variables.
   # As the heredoc identifier, we'll use a randomly generated 64-character string,
   # so that collisions are practically impossible.
+  # Read more: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
   delimiter="$(openssl rand -hex 32)"
 
   if [ "$INPUT_EXPORT_ENV" == "true" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,7 @@ install_op_cli() {
   OP_CLI_VERSION="v$(curl https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N -s | jq -r .version)"
 
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Get runner's architecture
     ARCH=$(uname -m)
     if [[ "$(getconf LONG_BIT)" = 32 ]]; then
       ARCH="386"
@@ -60,6 +61,12 @@ install_op_cli() {
     elif [[ "$ARCH" == "aarch64" ]]; then
       ARCH="arm64"
     fi
+
+    if [[ "$ARCH" != "386" ]] && [[ "$ARCH" == "amd64" ]] && [[ "$ARCH" == "arm" ]] && [[ "$ARCH" == "arm64" ]]; then
+      echo "Unsupported architecture for the 1Password CLI: $ARCH."
+      exit 1
+    fi
+
     curl -sSfLo op.zip "https://cache.agilebits.com/dist/1P/op2/pkg/${OP_CLI_VERSION}/op_linux_${ARCH}_${OP_CLI_VERSION}.zip"
     unzip -od "$OP_INSTALL_DIR" op.zip && rm op.zip
   elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Key changes in this PR:
- Use the new syntax for setting a step's output since [the old one is deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
- Automatically fetch the latest stable version of the CLI.
- Add additional architectures for Linux
- Make the action fail if the GitHub Action runner's operating system is not supported.

Resolves: #27