### PR TITLE
Parse CLI version without jq

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ install_op_cli() {
   echo "::debug::OP_INSTALL_DIR: ${OP_INSTALL_DIR}"
 
   # Get the latest stable version of the CLI
-  OP_CLI_VERSION="v$(curl https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N -s | jq -r .version)"
+  OP_CLI_VERSION="v$(curl https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N -s | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')"
 
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Get runner's architecture


### PR DESCRIPTION
It seems that we can't assume that images have `jq` built-in, therefore we will use `grep` which comes built-in with all UNIX systems.

Resolves: #50