### PR TITLE
Fix example snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
           SECRET: op://app-cicd/hello-world/secret
 
       - name: Print masked secret
-        run: echo "Secret: $SECRET"
+        run: 'echo "Secret: $SECRET"'
         # Prints: Secret: ***
 ```
 


### PR DESCRIPTION
The code example in the README is currently broken because of the syntax used to print the string Secret: ahead of the output. YAML requires strings that include special characters like : to be [enclosed with quotes to print correctly as a string](https://stackoverflow.com/questions/19109912/yaml-do-i-need-quotes-for-strings-in-yaml). This MR fixes that.