### PR TITLE
Remove protocol prepending

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ matrix.auth == 'connect' }}
         uses: ./configure # 1password/load-secrets-action/configure@<version>
         with:
-          connect-host: localhost:8080
+          connect-host: http://localhost:8080
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
       - name: Load secrets
         id: load_secrets

--- a/dist/index.js
+++ b/dist/index.js
@@ -30086,15 +30086,6 @@ const validateAuth = () => {
         throw new Error(authErr);
     }
     const authType = isConnect ? "Connect" : "Service account";
-    // Adjust Connect host to have a protocol
-    if (process.env[envConnectHost] &&
-        // The following lint error is not an issue because we are checking for the presence of the `http://` prefix;
-        // we are not using it as an insecure connection protocol to link out to another resource.
-        // eslint-disable-next-line no-restricted-syntax
-        !process.env[envConnectHost].startsWith("http://") &&
-        !process.env[envConnectHost].startsWith("https://")) {
-        process.env[envConnectHost] = `http://${process.env[envConnectHost]}`;
-    }
     core.info(`Authenticated with ${authType}.`);
 };
 const extractSecret = (envName, shouldExportEnv) => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -47,23 +47,6 @@ describe("validateAuth", () => {
 		expect(validateAuth).toThrowError(authErr);
 	});
 
-	it("should append protocol if Connect host doesn't have it", () => {
-		process.env[envConnectHost] = "localhost:8080";
-		process.env[envConnectToken] = testConnectToken;
-		expect(validateAuth).not.toThrowError(authErr);
-		// The following lint error is not an issue because we are checking for the presence of the `http://` prefix;
-		// we are not using it as an insecure connection protocol to link out to another resource.
-		// eslint-disable-next-line no-restricted-syntax
-		expect(process.env[envConnectHost]).toBe("http://localhost:8080");
-	});
-
-	it("should not append protocol if Connect host has one", () => {
-		process.env[envConnectHost] = testConnectHost;
-		process.env[envConnectToken] = testConnectToken;
-		expect(validateAuth).not.toThrowError(authErr);
-		expect(process.env[envConnectHost]).toBe(testConnectHost);
-	});
-
 	it("should be authenticated as a Connect client", () => {
 		process.env[envConnectHost] = testConnectHost;
 		process.env[envConnectToken] = testConnectToken;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,18 +26,6 @@ export const validateAuth = (): void => {
 
 	const authType = isConnect ? "Connect" : "Service account";
 
-	// Adjust Connect host to have a protocol
-	if (
-		process.env[envConnectHost] &&
-		// The following lint error is not an issue because we are checking for the presence of the `http://` prefix;
-		// we are not using it as an insecure connection protocol to link out to another resource.
-		// eslint-disable-next-line no-restricted-syntax
-		!process.env[envConnectHost].startsWith("http://") &&
-		!process.env[envConnectHost].startsWith("https://")
-	) {
-		process.env[envConnectHost] = `http://${process.env[envConnectHost]}`;
-	}
-
 	core.info(`Authenticated with ${authType}.`);
 };
 


### PR DESCRIPTION
This code is no longer needed. Instead, we will enforce users to add the protocol themselves.