### PR TITLE
Prepare release v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         with:
           # Export loaded secrets as environment variables
           export-env: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -30062,7 +30062,7 @@ var exec = __nccwpck_require__(1514);
 // EXTERNAL MODULE: ./node_modules/@1password/op-js/dist/index.js
 var dist = __nccwpck_require__(7091);
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"i8":"1.2.0"};
+const package_namespaceObject = {"i8":"2.0.0"};
 ;// CONCATENATED MODULE: ./src/constants.ts
 const envConnectHost = "OP_CONNECT_HOST";
 const envConnectToken = "OP_CONNECT_TOKEN";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "load-secrets-action",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "load-secrets-action",
-			"version": "1.2.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@1password/op-js": "^0.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
 			"devDependencies": {
 				"@1password/front-end-style": "^6.0.1",
 				"@types/jest": "^29.5.12",
-				"@types/node": "^20.11.19",
+				"@types/node": "^20.11.30",
 				"@vercel/ncc": "^0.38.1",
 				"husky": "^9.0.11",
 				"jest": "^29.7.0",
 				"lint-staged": "^15.2.2",
 				"ts-jest": "^29.1.2",
-				"typescript": "^5.3.3"
+				"typescript": "^5.4.2"
 			}
 		},
 		"node_modules/@1password/front-end-style": {
@@ -1619,9 +1619,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "20.11.19",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.19.tgz",
-			"integrity": "sha512-7xMnVEcZFu0DikYjWOlRq7NTPETrm7teqUT2WkQjrTIkEgUyyGdWsj/Zg8bEJt5TNklzbPD1X3fqfsHw3SpapQ==",
+			"version": "20.11.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
+			"integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -8290,9 +8290,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+			"integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-secrets-action",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"description": "Load Secrets from 1Password",
 	"type": "module",
 	"main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
 	"devDependencies": {
 		"@1password/front-end-style": "^6.0.1",
 		"@types/jest": "^29.5.12",
-		"@types/node": "^20.11.19",
+		"@types/node": "^20.11.30",
 		"@vercel/ncc": "^0.38.1",
 		"husky": "^9.0.11",
 		"jest": "^29.7.0",
 		"lint-staged": "^15.2.2",
 		"ts-jest": "^29.1.2",
-		"typescript": "^5.3.3"
+		"typescript": "^5.4.2"
 	},
 	"eslintConfig": {
 		"extends": "./node_modules/@1password/front-end-style/eslintrc.yml",


### PR DESCRIPTION
This PR prepares the release of Load Secrets - GitHub Action v2.0.0

Resolves #61 

### Breaking changes

- Users are now required to include the protocol (i.e. `http://` or `https://`) when providing the Connect server host URL.

### Other changes

- Upgrade from Node 16 to Node 20.
- Migrate the functionality of the action from Shell to Typescript (except installing the 1Password CLI) 