### PR TITLE
Run 1Password/check-signed-commits-action for PRs

### DIFF
--- a/.github/workflows/pr-check-signed-commits.yml
+++ b/.github/workflows/pr-check-signed-commits.yml
@@ -1,0 +1,13 @@
+name: Check signed commits in PR
+on: pull_request_target
+
+jobs:
+  build:
+    name: Check signed commits in PR
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1


### PR DESCRIPTION
Add the [check-signed-commits-action](https://github.com/1Password/check-signed-commits-action) that will leave a handy comment if a PR contains commits that are not signed.