### PR TITLE
Switch to /usr/bin/env bash in entrypoint.sh

### DIFF
--- a/configure/entrypoint.sh
+++ b/configure/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2086
 set -e
 


### PR DESCRIPTION
Using hardcoded paths (`/bin/bash`) is generally a bad practice.
Please use the POSIX compliant `/usr/bin/env bash` instead.
Self-hosted runners that use a system like NixOS will currently fail to use the 1Password Action.