### PR TITLE
Update bug bounty process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
-          docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+          docker compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
       - name: Configure Service account
         if: ${{ matrix.auth == 'service-account' }}
         uses: ./configure
@@ -73,7 +73,7 @@ jobs:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
-          docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+          docker compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
       - name: Configure Service account
         if: ${{ matrix.auth == 'service-account' }}
         uses: ./configure
@@ -117,7 +117,7 @@ jobs:
           OP_CONNECT_CREDENTIALS: ${{ secrets.OP_CONNECT_CREDENTIALS }}
         run: |
           echo "$OP_CONNECT_CREDENTIALS" > 1password-credentials.json
-          docker-compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
+          docker compose -f tests/fixtures/docker-compose.yml up -d && sleep 10
       - name: Configure Service account
         if: ${{ matrix.auth == 'service-account' }}
         uses: ./configure

--- a/README.md
+++ b/README.md
@@ -55,6 +55,4 @@ jobs:
 
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
-Please file requests via [**BugCrowd**](https://bugcrowd.com/agilebits).
-
-For information about security practices, please visit the [1Password Bug Bounty Program](https://bugcrowd.com/agilebits).
+Please file requests by sending an email to bugbounty@agilebits.com.


### PR DESCRIPTION
Update the Security section of the README to point to the new method of bug bounty reporting for this repo.

Also fix the `docker compose` command since the deprecated alias (`docker-compose`) is no longer present.