### PR TITLE
Make workflow targets more specific

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,7 @@
-on: pull_request
+on:
+  push:
+    branch: [main]
+  pull_request:
 name: Lint
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branch: [main]
+  pull_request:
 name: Run acceptance tests
 
 jobs:


### PR DESCRIPTION
This ensures that:
- `Acceptance tests` workflow is run on pull requests (including the ones from external contributors)
- `Lint` is run on `main` branch.
- Workflows are executed only once on pull requests

**Context:** It was noticed that the `Acceptance tests` workflow was not executed on #82 which made the review cycle take way longer and required extra effort to identify bugs and regressions.