### PR TITLE
Fix workflow branch syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branch: [main]
+    branches: [main]
   pull_request:
 name: Lint
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branch: [main]
+    branches: [main]
   pull_request:
 name: Run acceptance tests
 


### PR DESCRIPTION
In a previous PR (#87) we used `branch` syntax to trigger the pipeline when a push on `main` was made. This was a mistake and [`branches`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs) is the correct syntax that achieves this.