### PR TITLE
Run acceptance tests on fork

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -1,0 +1,25 @@
+# If someone with write access comments "/ok-to-test" on a pull request, emit a repository_dispatch event
+name: Ok To Test
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ok-to-test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # For adding reactions to the pull request comments
+      contents: write # For executing the repository_dispatch event
+    # Only run for PRs, not issue comments
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-type: pull-request
+          commands: ok-to-test
+          # The repository permission level required by the user to dispatch commands. Only allows 1Password collaborators to run this.
+          permission: write

--- a/.github/workflows/test-fork.yml
+++ b/.github/workflows/test-fork.yml
@@ -1,0 +1,92 @@
+on:
+  repository_dispatch:
+    types: [ok-to-test-command]
+name: Run acceptance tests [fork]
+
+jobs:
+  test-with-output-secrets:
+    if: |
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    uses: ./.github/workflows/acceptance-test.yml
+    secrets: inherit
+    with:
+      secret: op://acceptance-tests/test-secret/password
+      secret-in-section: op://acceptance-tests/test-secret/test-section/password
+      multiline-secret: op://acceptance-tests/multiline-secret/notesPlain
+      export-env: false
+  test-with-export-env:
+    if: |
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    uses: ./.github/workflows/acceptance-test.yml
+    secrets: inherit
+    with:
+      secret: op://acceptance-tests/test-secret/password
+      secret-in-section: op://acceptance-tests/test-secret/test-section/password
+      multiline-secret: op://acceptance-tests/multiline-secret/notesPlain
+      export-env: true
+  test-references-with-ids:
+    if: |
+      github.event_name == 'repository_dispatch' &&
+      github.event.client_payload.slash_command.args.named.sha != '' &&
+      contains(
+        github.event.client_payload.pull_request.head.sha,
+        github.event.client_payload.slash_command.args.named.sha
+      )
+    uses: ./.github/workflows/acceptance-test.yml
+    secrets: inherit
+    with:
+      secret: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password
+      secret-in-section: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/Section_tco6nsqycj6jcbyx63h5isxcny/doxu3mhkozcznnk5vjrkpdqayy
+      multiline-secret: op://v5pz6venw4roosmkzdq2nhpv6u/ghtz3jvcc6dqmzc53d3r3eskge/notesPlain
+      export-env: false
+  update-checks:
+    # required permissions for updating the status of the pull request checks
+    permissions:
+      pull-requests: write
+      checks: write
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    strategy:
+      matrix:
+        job-name:
+          [
+            test-with-output-secrets,
+            test-with-export-env,
+            test-references-with-ids,
+          ]
+    needs:
+      [test-with-output-secrets, test-with-export-env, test-references-with-ids]
+    steps:
+      - uses: actions/github-script@v6
+        env:
+          job: ${{ matrix.job-name }}
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          conclusion: ${{ needs[format('{0}', matrix.job-name )].result }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref: process.env.ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === process.env.job);
+
+            const { data: result } = await github.rest.checks.update({
+              ...context.repo,
+              check_run_id: check[0].id,
+              status: 'completed',
+              conclusion: process.env.conclusion
+            });
+
+            return result;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,12 @@ jobs:
       - run: npm ci
       - run: npm test
   test-with-output-secrets:
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' && 
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     uses: ./.github/workflows/acceptance-test.yml
     secrets: inherit
     with:
@@ -23,6 +29,12 @@ jobs:
       multiline-secret: op://acceptance-tests/multiline-secret/notesPlain
       export-env: false
   test-with-export-env:
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' && 
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     uses: ./.github/workflows/acceptance-test.yml
     secrets: inherit
     with:
@@ -31,6 +43,12 @@ jobs:
       multiline-secret: op://acceptance-tests/multiline-secret/notesPlain
       export-env: true
   test-references-with-ids:
+    if: |
+      github.ref == 'refs/heads/main' ||
+      (
+        github.event_name == 'pull_request' && 
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     uses: ./.github/workflows/acceptance-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Currently an external contributor can't have the acceptance tests run on their PR because `pull_request` doesn't give access to the secrets needed for them.

Therefore, in this PR we create a new workflow that is identical to the one for existing acceptance tests, with the following differences:
- This workflow can be triggered with the command `/ok-to-test sha="<contributor's latest commit sha>"` by one of this repo's maintainers.
- After the acceptance tests finish, their result will be updated to the PR's list of checks.