### PR TITLE
Fix fork workflow

### DIFF
--- a/.github/workflows/acceptance-test.yml
+++ b/.github/workflows/acceptance-test.yml
@@ -29,6 +29,26 @@ jobs:
     steps:
       - name: Base checkout
         uses: actions/checkout@v4
+        if: |
+          github.event_name != 'repository_dispatch' &&
+          (
+            github.ref == 'refs/heads/main' || 
+            (
+              github.event_name == 'pull_request' && 
+              github.event.pull_request.head.repo.full_name == github.repository
+            )
+          )
+      - name: Fork based /ok-to-test checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+        if: |
+          github.event_name == 'repository_dispatch' &&
+          github.event.client_payload.slash_command.args.named.sha != '' &&
+          contains(
+            github.event.client_payload.pull_request.head.sha,
+            github.event.client_payload.slash_command.args.named.sha
+          )
       - name: Launch 1Password Connect instance
         if: ${{ matrix.auth == 'connect' }}
         env:

--- a/.github/workflows/test-fork.yml
+++ b/.github/workflows/test-fork.yml
@@ -12,7 +12,7 @@ jobs:
         github.event.client_payload.pull_request.head.sha,
         github.event.client_payload.slash_command.args.named.sha
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://acceptance-tests/test-secret/password
@@ -27,7 +27,7 @@ jobs:
         github.event.client_payload.pull_request.head.sha,
         github.event.client_payload.slash_command.args.named.sha
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://acceptance-tests/test-secret/password
@@ -42,7 +42,7 @@ jobs:
         github.event.client_payload.pull_request.head.sha,
         github.event.client_payload.slash_command.args.named.sha
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://acceptance-tests/test-secret/password
@@ -35,7 +35,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://acceptance-tests/test-secret/password
@@ -49,7 +49,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: ./.github/workflows/acceptance-test.yml
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     with:
       secret: op://v5pz6venw4roosmkzdq2nhpv6u/hrgkzhrlvscomepxlgafb2m3ca/password


### PR DESCRIPTION
In #97 it was missed to adjust the reusable workflow to pull changes from the forked commit. Instead, now we pull from base repository, which doesn't contain the external contributor's changes.

I've also improved the way we reference the reusable workflow to ensure we're using a trusted reusable workflow that won't change often.