### PR TITLE
Set default for `version` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   export-env:
     description: Export the secrets as environment variables
     default: "true"
+  version:
+    description: Specify which 1Password CLI version to install. Defaults to "latest".
+    default: "latest"
 runs:
   using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
This PR sets default 1password cli version to `latest`