### PR TITLE
Bump op-cli-installer version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@vzt/use-op-cli-installer #TODO: after merge, this to main, revert to consume yml file from main (delete '@vzt/use-op-cli-installer')
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     strategy:
       matrix:
@@ -50,7 +50,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@vzt/use-op-cli-installer #TODO: after merge, this to main, revert to consume yml file from main (delete '@vzt/use-op-cli-installer')
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     strategy:
       matrix:
@@ -78,7 +78,7 @@ jobs:
         github.event_name == 'pull_request' && 
         github.event.pull_request.head.repo.full_name == github.repository
       )
-    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@vzt/use-op-cli-installer #TODO: after merge, this to main, revert to consume yml file from main (delete '@vzt/use-op-cli-installer')
+    uses: 1password/load-secrets-action/.github/workflows/acceptance-test.yml@main
     secrets: inherit
     strategy:
       matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@1password/op-js": "^0.1.11",
 				"@actions/core": "^1.10.1",
 				"@actions/exec": "^1.1.1",
-				"op-cli-installer": "github:1Password/op-cli-installer#f3ef8d8e0651def3e5fe6234043f09b3298d2148"
+				"op-cli-installer": "github:1Password/op-cli-installer#4d43923d7a7de1532741ca93815934e78087e69b"
 			},
 			"devDependencies": {
 				"@1password/eslint-config": "^4.3.1",
@@ -6388,8 +6388,8 @@
 		},
 		"node_modules/op-cli-installer": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/1Password/op-cli-installer.git#f3ef8d8e0651def3e5fe6234043f09b3298d2148",
-			"integrity": "sha512-k8mp0gMwYuz8uDdpUw2vQPdcRuQBUiWAAK8pJ2q90uekdYcSABVaKP6qQwrtxDcN+J1tjH32+l6+a5kX8eM/rw==",
+			"resolved": "git+ssh://git@github.com/1Password/op-cli-installer.git#4d43923d7a7de1532741ca93815934e78087e69b",
+			"integrity": "sha512-ueyYQAgtbIHP2QWx9iCiztoPov01GdxPZNZ4+Qg3IaAyC4khMIk4/vYPagRhRKta+HI6fWV6jO3/ajBj27KBZA==",
 			"license": "MIT",
 			"dependencies": {
 				"@actions/core": "^1.11.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@1password/op-js": "^0.1.11",
 				"@actions/core": "^1.10.1",
 				"@actions/exec": "^1.1.1",
-				"op-cli-installer": "github:1Password/op-cli-installer#4d43923d7a7de1532741ca93815934e78087e69b"
+				"op-cli-installer": "github:1Password/op-cli-installer#e6c1c758bc3339e5fe9b06255728039f688f73fa"
 			},
 			"devDependencies": {
 				"@1password/eslint-config": "^4.3.1",
@@ -6388,7 +6388,7 @@
 		},
 		"node_modules/op-cli-installer": {
 			"version": "1.0.0",
-			"resolved": "git+ssh://git@github.com/1Password/op-cli-installer.git#4d43923d7a7de1532741ca93815934e78087e69b",
+			"resolved": "git+ssh://git@github.com/1Password/op-cli-installer.git#e6c1c758bc3339e5fe9b06255728039f688f73fa",
 			"integrity": "sha512-ueyYQAgtbIHP2QWx9iCiztoPov01GdxPZNZ4+Qg3IaAyC4khMIk4/vYPagRhRKta+HI6fWV6jO3/ajBj27KBZA==",
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@1password/op-js": "^0.1.11",
 		"@actions/core": "^1.10.1",
 		"@actions/exec": "^1.1.1",
-		"op-cli-installer": "github:1Password/op-cli-installer#f3ef8d8e0651def3e5fe6234043f09b3298d2148"
+		"op-cli-installer": "github:1Password/op-cli-installer#4d43923d7a7de1532741ca93815934e78087e69b"
 	},
 	"devDependencies": {
 		"@1password/eslint-config": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@1password/op-js": "^0.1.11",
 		"@actions/core": "^1.10.1",
 		"@actions/exec": "^1.1.1",
-		"op-cli-installer": "github:1Password/op-cli-installer#4d43923d7a7de1532741ca93815934e78087e69b"
+		"op-cli-installer": "github:1Password/op-cli-installer#e6c1c758bc3339e5fe9b06255728039f688f73fa"
 	},
 	"devDependencies": {
 		"@1password/eslint-config": "^4.3.1",


### PR DESCRIPTION
This PR:
- Bumps `op-cli-installer` version to the latest which sets default cli version if not provided by the caller.
- Reverts acceptance-test to point to the `main` branch.

