### PR TITLE
Set `export-env` input to `false` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Read more on the [1Password Developer Portal](https://developer.1password.com/do
 
 ## ✨ Quickstart
 
-### Use secrets from step output (recommended)
+### Export secrets as a step's output (recommended)
 
 ```yml
 on: push
@@ -56,10 +56,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Load secret
-        id: load_secret
         uses: 1password/load-secrets-action@v3
         with:
-          export-env: "true"
+          # Export loaded secrets as environment variables
+          export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://app-cicd/hello-world/secret

--- a/README.md
+++ b/README.md
@@ -23,19 +23,41 @@ Read more on the [1Password Developer Portal](https://developer.1password.com/do
 
 ## ✨ Quickstart
 
+### Use secrets from step output (recommended)
 ```yml
 on: push
 jobs:
   hello-world:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load secret
-        uses: 1password/load-secrets-action@v2
+        id: load_secret
+        uses: 1password/load-secrets-action@v3
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SECRET: op://app-cicd/hello-world/secret
+
+      - name: Print masked secret
+        run: 'echo "Secret: ${{ steps.load_secrets.outputs.SECRET }}"'
+        # Prints: Secret: ***
+```
+
+### Export secrets as env variables
+```yml
+on: push
+jobs:
+  hello-world:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Load secret
+        id: load_secret
+        uses: 1password/load-secrets-action@v3
         with:
-          # Export loaded secrets as environment variables
-          export-env: true
+          export-env: 'true'
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://app-cicd/hello-world/secret

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Read more on the [1Password Developer Portal](https://developer.1password.com/do
 ## ✨ Quickstart
 
 ### Use secrets from step output (recommended)
+
 ```yml
 on: push
 jobs:
@@ -45,6 +46,7 @@ jobs:
 ```
 
 ### Export secrets as env variables
+
 ```yml
 on: push
 jobs:
@@ -57,7 +59,7 @@ jobs:
         id: load_secret
         uses: 1password/load-secrets-action@v3
         with:
-          export-env: 'true'
+          export-env: "true"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://app-cicd/hello-world/secret

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: "false"
   export-env:
     description: Export the secrets as environment variables
-    default: "true"
+    default: "false"
   version:
     description: Specify which 1Password CLI version to install. Defaults to "latest".
     default: "latest"


### PR DESCRIPTION
As we anyway plan to release [v3](https://github.com/1Password/load-secrets-action/pull/110), I think this is a good opportunity to introduce this breaking change.

So, in `v3` of the action the `export-env` input will defaults to `false`.
This will help to mitigate the next security concern. As exporting secret as env variable in the job will make it available for all future steps including 3d party actions. If some malicious 3d party action is used it can get an access to the secret from env var.

Though, the risk is low, the safer way for the action would be to defaults to `false` and let the users explicitly set `export-env` input, if they want to export secrets as env variables.

This PR also updates readme to show reccomended example of using secrets as step outputs as well as exporting secrets as env vars.

Resolves #79 