### PR TITLE
feature: enable loading 1password secrets from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://app-cicd/hello-world/secret
+          OP_ENV_FILE: "path/to/.env.tpl"
 
       - name: Print masked secret
         run: 'echo "Secret: ${{ steps.load_secrets.outputs.SECRET }}"'
@@ -63,6 +64,7 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           SECRET: op://app-cicd/hello-world/secret
+          OP_ENV_FILE: "path/to/.env.tpl"
 
       - name: Print masked secret
         run: 'echo "Secret: $SECRET"'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,5 +2,6 @@ export const envConnectHost = "OP_CONNECT_HOST";
 export const envConnectToken = "OP_CONNECT_TOKEN";
 export const envServiceAccountToken = "OP_SERVICE_ACCOUNT_TOKEN";
 export const envManagedVariables = "OP_MANAGED_VARIABLES";
+export const envFilePath = "OP_ENV_FILE";
 
 export const authErr = `Authentication error with environment variables: you must set either 1) ${envServiceAccountToken}, or 2) both ${envConnectHost} and ${envConnectToken}.`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import * as core from "@actions/core";
 import { validateCli } from "@1password/op-js";
 import { installCliOnGithubActionRunner } from "op-cli-installer";
 import { loadSecrets, unsetPrevious, validateAuth } from "./utils";
+import {
+	envFilePath,
+} from "./constants";
 
 const loadSecretsAction = async () => {
 	try {
@@ -19,6 +22,13 @@ const loadSecretsAction = async () => {
 
 		// Download and install the CLI
 		await installCLI();
+
+		// Set environment variables from OP_ENV_FILE
+		const file = process.env[envFilePath];
+		if (file) {
+			core.info(`Loading environment variables from file: ${file}`);
+			process.loadEnvFile(file)
+		}
 
 		// Load secrets
 		await loadSecrets(shouldExportEnv);


### PR DESCRIPTION
I hope this approach with loading 1password environment variables from an 1password specific env file can solve below feature request.

Fixes #93 