### PR TITLE
fix: set outputs/env vars for empty string field values

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -106,6 +106,41 @@ describe("extractSecret", () => {
 		);
 		expect(core.setSecret).toHaveBeenCalledWith(testSecretValue);
 	});
+
+	describe("when secret value is empty string", () => {
+		const emptySecretValue = "";
+
+		beforeEach(() => {
+			(read.parse as jest.Mock).mockReturnValue(emptySecretValue);
+		});
+
+		afterEach(() => {
+			(read.parse as jest.Mock).mockReturnValue(testSecretValue);
+		});
+
+		it("should set empty string as step output", () => {
+			extractSecret(envTestSecretEnv, false);
+			expect(core.setOutput).toHaveBeenCalledWith(
+				envTestSecretEnv,
+				emptySecretValue,
+			);
+			expect(core.exportVariable).not.toHaveBeenCalled();
+		});
+
+		it("should set empty string as environment variable", () => {
+			extractSecret(envTestSecretEnv, true);
+			expect(core.exportVariable).toHaveBeenCalledWith(
+				envTestSecretEnv,
+				emptySecretValue,
+			);
+			expect(core.setOutput).not.toHaveBeenCalled();
+		});
+
+		it("should not call setSecret for empty string", () => {
+			extractSecret(envTestSecretEnv, false);
+			expect(core.setSecret).not.toHaveBeenCalled();
+		});
+	});
 });
 
 describe("loadSecrets", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export const extractSecret = (
 	}
 
 	const secretValue = read.parse(ref);
-	if (!secretValue) {
+	if (secretValue === null || secretValue === undefined) {
 		return;
 	}
 
@@ -50,7 +50,11 @@ export const extractSecret = (
 	} else {
 		core.setOutput(envName, secretValue);
 	}
-	core.setSecret(secretValue);
+	// Skip setSecret for empty strings to avoid the warning:
+	// "Can't add secret mask for empty string in ##[add-mask] command."
+	if (secretValue) {
+		core.setSecret(secretValue);
+	}
 };
 
 export const loadSecrets = async (shouldExportEnv: boolean): Promise<void> => {


### PR DESCRIPTION
- Fix inconsistent behavior where empty string field values from 1Password caused outputs/env vars to be undefined
- Now matches `op run` behavior: empty field values result in defined variables with empty string values
- Skip `setSecret` for empty strings to avoid runner warning

Fixes #131 
