### PR TITLE
fix 1Password cli installer error on Windows

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35421,6 +35421,9 @@ class MacOsInstaller extends CliInstaller {
 
 ;// CONCATENATED MODULE: ./src/op-cli-installer/github-action/cli-installer/windows.ts
 
+
+
+
 class WindowsInstaller extends CliInstaller {
     platform = "win32"; // Node.js platform identifier for Windows
     constructor(version) {
@@ -35428,7 +35431,19 @@ class WindowsInstaller extends CliInstaller {
     }
     async installCli() {
         const urlBuilder = cliUrlBuilder[this.platform];
-        await super.install(urlBuilder(this.version, this.arch));
+        await this.install(urlBuilder(this.version, this.arch));
+    }
+    // Windows PowerShell's Expand-Archive requires files to have a .zip extension.
+    // tc.downloadTool saves to a UUID filename with no extension, so we rename it.
+    async install(url) {
+        console.info(`Downloading 1Password CLI from: ${url}`);
+        const downloadPath = await downloadTool(url);
+        const zipPath = `${downloadPath}.zip`;
+        external_fs_.renameSync(downloadPath, zipPath);
+        console.info("Installing 1Password CLI");
+        const extractedPath = await extractZip(zipPath);
+        addPath(extractedPath);
+        info("1Password CLI installed");
     }
 }
 

--- a/src/op-cli-installer/github-action/cli-installer/windows.test.ts
+++ b/src/op-cli-installer/github-action/cli-installer/windows.test.ts
@@ -1,12 +1,17 @@
+import fs from "fs";
 import os from "os";
+
+import * as core from "@actions/core";
+import * as tc from "@actions/tool-cache";
 
 import {
 	archMap,
-	CliInstaller,
 	cliUrlBuilder,
 	type SupportedPlatform,
 } from "./cli-installer";
 import { WindowsInstaller } from "./windows";
+
+jest.mock("fs");
 
 afterEach(() => {
 	jest.restoreAllMocks();
@@ -25,14 +30,31 @@ describe("WindowsInstaller", () => {
 
 	it("should call install with correct URL", async () => {
 		const installer = new WindowsInstaller(version);
-		const installMock = jest
-			.spyOn(CliInstaller.prototype, "install")
-			.mockResolvedValue();
+		const installMock = jest.spyOn(installer, "install").mockResolvedValue();
 
 		await installer.installCli();
 
 		const builder = cliUrlBuilder["win32" as SupportedPlatform];
 		const url = builder(version, installer.arch);
 		expect(installMock).toHaveBeenCalledWith(url);
+	});
+
+	it("should rename downloaded file with .zip extension before extracting", async () => {
+		const downloadPath = "/tmp/abc-123";
+		const extractedPath = "/tmp/extracted";
+
+		(tc.downloadTool as jest.Mock).mockResolvedValue(downloadPath);
+		(tc.extractZip as jest.Mock).mockResolvedValue(extractedPath);
+
+		const installer = new WindowsInstaller(version);
+		await installer.installCli();
+
+		expect(tc.downloadTool).toHaveBeenCalled();
+		expect(fs.renameSync).toHaveBeenCalledWith(
+			downloadPath,
+			`${downloadPath}.zip`,
+		);
+		expect(tc.extractZip).toHaveBeenCalledWith(`${downloadPath}.zip`);
+		expect(core.addPath).toHaveBeenCalledWith(extractedPath);
 	});
 });

--- a/src/op-cli-installer/github-action/cli-installer/windows.ts
+++ b/src/op-cli-installer/github-action/cli-installer/windows.ts
@@ -1,3 +1,8 @@
+import * as fs from "fs";
+
+import * as core from "@actions/core";
+import * as tc from "@actions/tool-cache";
+
 import {
 	CliInstaller,
 	cliUrlBuilder,
@@ -14,6 +19,19 @@ export class WindowsInstaller extends CliInstaller implements Installer {
 
 	public async installCli(): Promise<void> {
 		const urlBuilder = cliUrlBuilder[this.platform];
-		await super.install(urlBuilder(this.version, this.arch));
+		await this.install(urlBuilder(this.version, this.arch));
+	}
+
+	// Windows PowerShell's Expand-Archive requires files to have a .zip extension.
+	// tc.downloadTool saves to a UUID filename with no extension, so we rename it.
+	public override async install(url: string): Promise<void> {
+		console.info(`Downloading 1Password CLI from: ${url}`);
+		const downloadPath = await tc.downloadTool(url);
+		const zipPath = `${downloadPath}.zip`;
+		fs.renameSync(downloadPath, zipPath);
+		console.info("Installing 1Password CLI");
+		const extractedPath = await tc.extractZip(zipPath);
+		core.addPath(extractedPath);
+		core.info("1Password CLI installed");
 	}
 }


### PR DESCRIPTION
Override install() in WindowsInstaller to rename the downloaded file with a .zip extension before extraction.

On Windows, @actions/tool-cache’s downloadTool() saves downloads using a random UUID filename with no extension. When pwsh is unavailable and only legacy powershell is present, extractZip() falls back to Expand-Archive, which requires the file to have a .zip extension. Before this change, extraction failed because the downloaded file had no .zip suffix.