### PR TITLE
Add Terms of Service to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Specify in your workflow YAML file which secrets from 1Password should be loaded
 
 Read more on the [1Password Developer Portal](https://developer.1password.com/docs/ci-cd/github-actions).
 
-*This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+_This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service)._
 
 ## 🪄 See it in action!
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Specify in your workflow YAML file which secrets from 1Password should be loaded
 
 Read more on the [1Password Developer Portal](https://developer.1password.com/docs/ci-cd/github-actions).
 
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+
 ## 🪄 See it in action!
 
 [![Using 1Password Service Accounts with GitHub Actions - showcase](https://img.youtube.com/vi/kVBl5iQYgSA/maxresdefault.jpg)](https://www.youtube.com/watch?v=kVBl5iQYgSA "Using 1Password Service Accounts with GitHub Actions")
@@ -97,6 +99,4 @@ For more details on secret reference syntax, see the [1Password CLI documentatio
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
-
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Specify in your workflow YAML file which secrets from 1Password should be loaded
 
 Read more on the [1Password Developer Portal](https://developer.1password.com/docs/ci-cd/github-actions).
 
-*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+*This project is licensed under [MIT](./LICENSE). Use of the 1Password APIs and services accessed through these tools is governed by the [1Password API Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
 
 ## 🪄 See it in action!
 

--- a/README.md
+++ b/README.md
@@ -99,4 +99,3 @@ For more details on secret reference syntax, see the [1Password CLI documentatio
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
-

--- a/README.md
+++ b/README.md
@@ -97,3 +97,6 @@ For more details on secret reference syntax, see the [1Password CLI documentatio
 1Password requests you practice responsible disclosure if you discover a vulnerability.
 
 Please file requests by sending an email to bugbounty@agilebits.com.
+
+*By accessing or using 1Password Developer Tools, you agree to the [API and SDK Terms of Service](https://1password.com/legal/api-sdk-terms-of-service).*
+


### PR DESCRIPTION
This PR adds our new terms of service to the README, as requested by the legal team.

This update needs to merge on June 5th.

Relates to: https://1password.atlassian.net/browse/TW-1153