### PR TITLE
Prepare Release v4.0.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35488,7 +35488,7 @@ const installCliOnGithubActionRunner = async (version) => {
 
 
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"rE":"4.0.0"};
+const package_namespaceObject = {"rE":"4.0.1"};
 ;// CONCATENATED MODULE: ./src/constants.ts
 const envConnectHost = "OP_CONNECT_HOST";
 const envConnectToken = "OP_CONNECT_TOKEN";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "load-secrets-action",
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@1password/op-js": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "Load Secrets from 1Password",
 	"main": "dist/index.js",
 	"directories": {


### PR DESCRIPTION
## Summary 

### Fix

- Fixed a Windows specific issue where 1Password CLI installation could fail because the downloaded archive lacked a .zip extension required by PowerShell’s archive extraction fallback. ([#154](https://github.com/1Password/load-secrets-action/pull/154))
- Bump actions/checkout from v5 to v6 in CI workflows. ([#156](https://github.com/1Password/load-secrets-action/pull/156))

### Security

- Harden GitHub Actions workflows by pinning external actions to immutable commit SHAs. ([#157](https://github.com/1Password/load-secrets-action/pull/157))

### Docs

- Add 1Password API Terms of Service notice to the README ([#166](https://github.com/1Password/load-secrets-action/pull/166))