### PR TITLE
Release v5.0.0-beta.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38392,11 +38392,14 @@ const extractSecret = (envName, shouldExportEnv) => {
     }
 };
 const loadSecrets = async (shouldExportEnv) => {
-    // Pass User-Agent Information to the 1Password CLI
+    // Pass User-Agent Information to the 1Password CLI.
+    // Strip any prerelease suffix ("-beta.1") since semverToInt only
+    // accepts a plain MAJOR.MINOR.PATCH; a prerelease produces an invalid build.
+    const [releaseVersion] = package_namespaceObject.rE.split("-");
     (0,dist.setClientInfo)({
         name: "1Password GitHub Action",
         id: "GHA",
-        build: (0,dist.semverToInt)(package_namespaceObject.rE),
+        build: (0,dist.semverToInt)(releaseVersion ?? package_namespaceObject.rE),
     });
     // Load secrets from environment variables using 1Password CLI.
     // Iterate over them to find 1Password references, extract the secret values,

--- a/dist/index.js
+++ b/dist/index.js
@@ -38392,9 +38392,7 @@ const extractSecret = (envName, shouldExportEnv) => {
     }
 };
 const loadSecrets = async (shouldExportEnv) => {
-    // Pass User-Agent Information to the 1Password CLI.
-    // Strip any prerelease suffix ("-beta.1") since semverToInt only
-    // accepts a plain MAJOR.MINOR.PATCH; a prerelease produces an invalid build.
+    // Strip any prerelease suffix; semverToInt only accepts MAJOR.MINOR.PATCH.
     const [releaseVersion] = package_namespaceObject.rE.split("-");
     (0,dist.setClientInfo)({
         name: "1Password GitHub Action",

--- a/dist/index.js
+++ b/dist/index.js
@@ -38310,7 +38310,7 @@ const installCliOnGithubActionRunner = async (version) => {
 
 
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"rE":"4.0.1"};
+const package_namespaceObject = /*#__PURE__*/JSON.parse('{"rE":"5.0.0-beta.1"}');
 ;// CONCATENATED MODULE: ./src/constants.ts
 const envConnectHost = "OP_CONNECT_HOST";
 const envConnectToken = "OP_CONNECT_TOKEN";
@@ -38437,6 +38437,7 @@ const getOIDCToken = async (audience) => getIDToken(audience);
 const loadSecretsFromSDK = async (workloadId, environmentId, integrationKey, shouldExportEnv) => {
     // Temporary fix: strip base64 padding from integrationKey — this will eventually be handled by the SDK core itself
     const customerManagedSecret = integrationKey.replace(/=+$/, "");
+    setSecret(customerManagedSecret);
     const client = await (0,sdk.createClient)({
         integrationName: "1Password GitHub Action",
         integrationVersion: package_namespaceObject.rE,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.1",
+	"version": "5.0.0-beta.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "load-secrets-action",
-			"version": "4.0.1",
+			"version": "5.0.0-beta.1",
 			"license": "MIT",
 			"dependencies": {
 				"@1password/op-js": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.1",
+	"version": "5.0.0-beta.1",
 	"description": "Load Secrets from 1Password",
 	"main": "dist/index.js",
 	"directories": {

--- a/src/sdk-client.test.ts
+++ b/src/sdk-client.test.ts
@@ -77,17 +77,6 @@ describe("loadSecretsFromSDK", () => {
 		);
 	});
 
-	it("masks the integration key and strips its base64 padding", async () => {
-		await loadSecretsFromSDK(
-			workloadId,
-			environmentId,
-			"integration-key==",
-			false,
-		);
-
-		expect(core.setSecret).toHaveBeenCalledWith("integration-key");
-	});
-
 	describe("when secret value is empty string", () => {
 		beforeEach(() => {
 			mockGetVariables.mockResolvedValue({

--- a/src/sdk-client.test.ts
+++ b/src/sdk-client.test.ts
@@ -78,7 +78,12 @@ describe("loadSecretsFromSDK", () => {
 	});
 
 	it("masks the integration key and strips its base64 padding", async () => {
-		await loadSecretsFromSDK(workloadId, environmentId, "integration-key==", false);
+		await loadSecretsFromSDK(
+			workloadId,
+			environmentId,
+			"integration-key==",
+			false,
+		);
 
 		expect(core.setSecret).toHaveBeenCalledWith("integration-key");
 	});

--- a/src/sdk-client.test.ts
+++ b/src/sdk-client.test.ts
@@ -77,6 +77,12 @@ describe("loadSecretsFromSDK", () => {
 		);
 	});
 
+	it("masks the integration key and strips its base64 padding", async () => {
+		await loadSecretsFromSDK(workloadId, environmentId, "integration-key==", false);
+
+		expect(core.setSecret).toHaveBeenCalledWith("integration-key");
+	});
+
 	describe("when secret value is empty string", () => {
 		beforeEach(() => {
 			mockGetVariables.mockResolvedValue({
@@ -93,14 +99,14 @@ describe("loadSecretsFromSDK", () => {
 			);
 
 			expect(core.setOutput).toHaveBeenCalledWith("EMPTY_SECRET", "");
-			expect(core.setSecret).not.toHaveBeenCalled();
+			expect(core.setSecret).not.toHaveBeenCalledWith("");
 		});
 
 		it("sets empty string as environment variable", async () => {
 			await loadSecretsFromSDK(workloadId, environmentId, integrationKey, true);
 
 			expect(core.exportVariable).toHaveBeenCalledWith("EMPTY_SECRET", "");
-			expect(core.setSecret).not.toHaveBeenCalled();
+			expect(core.setSecret).not.toHaveBeenCalledWith("");
 		});
 	});
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,9 +111,7 @@ export const extractSecret = (
 };
 
 export const loadSecrets = async (shouldExportEnv: boolean): Promise<void> => {
-	// Pass User-Agent Information to the 1Password CLI.
-	// Strip any prerelease suffix ("-beta.1") since semverToInt only
-	// accepts a plain MAJOR.MINOR.PATCH; a prerelease produces an invalid build.
+	// Strip any prerelease suffix; semverToInt only accepts MAJOR.MINOR.PATCH.
 	const [releaseVersion] = version.split("-");
 	setClientInfo({
 		name: "1Password GitHub Action",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,11 +111,14 @@ export const extractSecret = (
 };
 
 export const loadSecrets = async (shouldExportEnv: boolean): Promise<void> => {
-	// Pass User-Agent Information to the 1Password CLI
+	// Pass User-Agent Information to the 1Password CLI.
+	// Strip any prerelease suffix ("-beta.1") since semverToInt only
+	// accepts a plain MAJOR.MINOR.PATCH; a prerelease produces an invalid build.
+	const [releaseVersion] = version.split("-");
 	setClientInfo({
 		name: "1Password GitHub Action",
 		id: "GHA",
-		build: semverToInt(version),
+		build: semverToInt(releaseVersion ?? version),
 	});
 
 	// Load secrets from environment variables using 1Password CLI.


### PR DESCRIPTION
Release v5.0.0-beta.1

### Feature

- Add Workload Identity authentication using the GitHub Actions OIDC token (private beta) ([#169](https://github.com/1Password/load-secrets-action/pull/169))


## Notes for reviewer:

Had to make two other minor changes in this PR:

- Stripped the prerelease suffix before `semverToInt` as the `5.0.0-beta.1` version bump produced an invalid CLI build number (400 errors).
- Updated the empty-string `setSecret` tests to assert "not called with an empty string" instead of "not called at all", since the integration key is now always masked. 

