### PR TITLE
feature: input of values not to mask

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   version:
     description: Specify which 1Password CLI version to install. Defaults to "latest".
     default: "latest"
+  unmask-values:
+    description: Specify an array of strings that should not be masked.
+    default: "[]"
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -35515,7 +35515,7 @@ const validateAuth = () => {
     const authType = isConnect ? "Connect" : "Service account";
     info(`Authenticated with ${authType}.`);
 };
-const extractSecret = (envName, shouldExportEnv) => {
+const extractSecret = (envName, shouldExportEnv, unmaskValues = []) => {
     info(`Populating variable: ${envName}`);
     const ref = process.env[envName];
     if (!ref) {
@@ -35533,11 +35533,11 @@ const extractSecret = (envName, shouldExportEnv) => {
     }
     // Skip setSecret for empty strings to avoid the warning:
     // "Can't add secret mask for empty string in ##[add-mask] command."
-    if (secretValue) {
+    if (secretValue && !unmaskValues.includes(secretValue)) {
         core_setSecret(secretValue);
     }
 };
-const loadSecrets = async (shouldExportEnv) => {
+const loadSecrets = async (shouldExportEnv, unmaskValues = []) => {
     // Pass User-Agent Information to the 1Password CLI
     (0,dist.setClientInfo)({
         name: "1Password GitHub Action",
@@ -35553,7 +35553,7 @@ const loadSecrets = async (shouldExportEnv) => {
     }
     const envs = res.stdout.replace(/\n+$/g, "").split(/\r?\n/);
     for (const envName of envs) {
-        extractSecret(envName, shouldExportEnv);
+        extractSecret(envName, shouldExportEnv, unmaskValues);
     }
     if (shouldExportEnv) {
         exportVariable(envManagedVariables, envs.join());
@@ -35582,6 +35582,11 @@ const loadSecretsAction = async () => {
         // Get action inputs
         const shouldUnsetPrevious = getBooleanInput("unset-previous");
         const shouldExportEnv = getBooleanInput("export-env");
+        const unmaskValues = JSON.parse(getInput("unmask-values"));
+        if (!(unmaskValues instanceof Array) ||
+            !unmaskValues.every((tag) => typeof tag === "string")) {
+            throw new Error("Invalid unmask-values input");
+        }
         // Unset all secrets managed by 1Password if `unset-previous` is set.
         if (shouldUnsetPrevious) {
             unsetPrevious();
@@ -35597,7 +35602,7 @@ const loadSecretsAction = async () => {
         // Download and install the CLI
         await installCLI();
         // Load secrets
-        await loadSecrets(shouldExportEnv);
+        await loadSecrets(shouldExportEnv, unmaskValues);
     }
     catch (error) {
         // It's possible for the Error constructor to be modified to be anything

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ const loadSecretsAction = async () => {
 		// Get action inputs
 		const shouldUnsetPrevious = core.getBooleanInput("unset-previous");
 		const shouldExportEnv = core.getBooleanInput("export-env");
+		const unmaskValues: unknown = JSON.parse(core.getInput("unmask-values"));
+		if (
+			!(unmaskValues instanceof Array) ||
+			!unmaskValues.every((tag) => typeof tag === "string")
+		) {
+			throw new Error("Invalid unmask-values input");
+		}
 
 		// Unset all secrets managed by 1Password if `unset-previous` is set.
 		if (shouldUnsetPrevious) {
@@ -30,7 +37,7 @@ const loadSecretsAction = async () => {
 		await installCLI();
 
 		// Load secrets
-		await loadSecrets(shouldExportEnv);
+		await loadSecrets(shouldExportEnv, unmaskValues);
 	} catch (error) {
 		// It's possible for the Error constructor to be modified to be anything
 		// in JavaScript, so the following code accounts for this possibility.

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -135,6 +135,27 @@ describe("extractSecret", () => {
 			expect(core.setSecret).not.toHaveBeenCalled();
 		});
 	});
+
+	describe("when secret value is configured to be unmasked", () => {
+		const unmaskedTestSecretValue = "unmasked";
+
+		beforeEach(() => {
+			(read.parse as jest.Mock).mockReturnValue(unmaskedTestSecretValue);
+		});
+
+		afterEach(() => {
+			(read.parse as jest.Mock).mockReturnValue(testSecretValue);
+		});
+
+		it("should not call setSecret for configured unmasked string", () => {
+			extractSecret(envTestSecretEnv, false, [unmaskedTestSecretValue]);
+			expect(core.setOutput).toHaveBeenCalledWith(
+				envTestSecretEnv,
+				unmaskedTestSecretValue,
+			);
+			expect(core.setSecret).not.toHaveBeenCalled();
+		});
+	});
 });
 
 describe("loadSecrets", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ export const validateAuth = (): void => {
 export const extractSecret = (
 	envName: string,
 	shouldExportEnv: boolean,
+	unmaskValues: string[] = [],
 ): void => {
 	core.info(`Populating variable: ${envName}`);
 
@@ -52,12 +53,15 @@ export const extractSecret = (
 	}
 	// Skip setSecret for empty strings to avoid the warning:
 	// "Can't add secret mask for empty string in ##[add-mask] command."
-	if (secretValue) {
+	if (secretValue && !unmaskValues.includes(secretValue)) {
 		core.setSecret(secretValue);
 	}
 };
 
-export const loadSecrets = async (shouldExportEnv: boolean): Promise<void> => {
+export const loadSecrets = async (
+	shouldExportEnv: boolean,
+	unmaskValues: string[] = [],
+): Promise<void> => {
 	// Pass User-Agent Information to the 1Password CLI
 	setClientInfo({
 		name: "1Password GitHub Action",
@@ -76,7 +80,7 @@ export const loadSecrets = async (shouldExportEnv: boolean): Promise<void> => {
 
 	const envs = res.stdout.replace(/\n+$/g, "").split(/\r?\n/);
 	for (const envName of envs) {
-		extractSecret(envName, shouldExportEnv);
+		extractSecret(envName, shouldExportEnv, unmaskValues);
 	}
 	if (shouldExportEnv) {
 		core.exportVariable(envManagedVariables, envs.join());


### PR DESCRIPTION
This PR is to resolve #94

## Summary
Add a new input (`unmask-values`) to designate specific values that should not be registered as secrets in order for those values to not be masked in logs or values passed between jobs.  

## Usage

```yaml
- uses: 1password/load-secrets-action@v4
  with:
    unmask-values: '["user-name", "company-name"]'
  env:
    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
```