### PR TITLE
Prepare Release v4.1.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34551,7 +34551,7 @@ var semver_default = /*#__PURE__*/__nccwpck_require__.n(node_modules_semver);
 
 const FALLBACK_VERSIONS = {
     [ReleaseChannel.latest]: "2.35.0",
-    [ReleaseChannel.latestBeta]: "2.37.0-beta.01",
+    [ReleaseChannel.latestBeta]: "2.38.0-beta.01",
 };
 
 ;// CONCATENATED MODULE: ./src/op-cli-installer/version/validate.ts
@@ -35659,7 +35659,7 @@ const installCliOnGithubActionRunner = async (version) => {
 
 
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"rE":"4.0.1"};
+const package_namespaceObject = {"rE":"4.1.1"};
 ;// CONCATENATED MODULE: ./src/constants.ts
 const envConnectHost = "OP_CONNECT_HOST";
 const envConnectToken = "OP_CONNECT_TOKEN";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.1",
+	"version": "4.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "load-secrets-action",
-			"version": "4.0.1",
+			"version": "4.1.1",
 			"license": "MIT",
 			"dependencies": {
 				"@1password/op-js": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-secrets-action",
-	"version": "4.0.1",
+	"version": "4.1.1",
 	"description": "Load Secrets from 1Password",
 	"main": "dist/index.js",
 	"directories": {

--- a/src/op-cli-installer/version/fallback-versions.ts
+++ b/src/op-cli-installer/version/fallback-versions.ts
@@ -5,5 +5,5 @@ import { ReleaseChannel } from "./constants";
 
 export const FALLBACK_VERSIONS: Record<ReleaseChannel, string> = {
 	[ReleaseChannel.latest]: "2.35.0",
-	[ReleaseChannel.latestBeta]: "2.37.0-beta.01",
+	[ReleaseChannel.latestBeta]: "2.38.0-beta.01",
 };


### PR DESCRIPTION
## What's Changed

### Features
- Add fallback version resolution so if app-updates.agilebits.com is unavailable, the action now falls back to Docker Hub and then a baked-in pinned version. (#173 )

### Security
- Harden CI security: add `StepSecurity` harden runner and pin GitHub Actions to commit SHAs across workflows, restrict workflow permissions, and add Dependabot config. (#174 )