### PR TITLE
Prepare Release v5.0.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37169,7 +37169,7 @@ var semver_default = /*#__PURE__*/__nccwpck_require__.n(node_modules_semver);
 
 const FALLBACK_VERSIONS = {
     [ReleaseChannel.latest]: "2.38.1",
-    [ReleaseChannel.latestBeta]: "2.38.1-beta.02",
+    [ReleaseChannel.latestBeta]: "2.39.0-beta.02",
 };
 
 ;// CONCATENATED MODULE: ./src/op-cli-installer/version/validate.ts
@@ -38277,7 +38277,7 @@ const installCliOnGithubActionRunner = async (version) => {
 
 
 ;// CONCATENATED MODULE: ./package.json
-const package_namespaceObject = {"rE":"5.0.0"};
+const package_namespaceObject = {"rE":"5.0.1"};
 ;// CONCATENATED MODULE: ./src/constants.ts
 const envConnectHost = "OP_CONNECT_HOST";
 const envConnectToken = "OP_CONNECT_TOKEN";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "load-secrets-action",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "load-secrets-action",
-			"version": "5.0.0",
+			"version": "5.0.1",
 			"license": "MIT",
 			"dependencies": {
 				"@1password/op-js": "^0.1.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "load-secrets-action",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "Load Secrets from 1Password",
 	"main": "dist/index.js",
 	"directories": {

--- a/src/op-cli-installer/version/fallback-versions.ts
+++ b/src/op-cli-installer/version/fallback-versions.ts
@@ -5,5 +5,5 @@ import { ReleaseChannel } from "./constants";
 
 export const FALLBACK_VERSIONS: Record<ReleaseChannel, string> = {
 	[ReleaseChannel.latest]: "2.38.1",
-	[ReleaseChannel.latestBeta]: "2.38.1-beta.02",
+	[ReleaseChannel.latestBeta]: "2.39.0-beta.02",
 };


### PR DESCRIPTION
## What's Changed

### Fixes

- Correct the authentication error message. It previously listed only the CLI methods (`OP_SERVICE_ACCOUNT_TOKEN`, or `OP_CONNECT_HOST` + `OP_CONNECT_TOKEN`), which misled anyone who meant to use Workload Identity but had one of those variables missing or misspelled. It now lists `OP_WORKLOAD_ID` + `OP_ENVIRONMENT_ID` + `OP_INTEGRATION_KEY` as a third valid option. (#187)

### Dependencies

- Bump `@1password/sdk` from `0.5.0-beta.1` to the stable `0.5.0`, and rebuild `dist/` (including `core_bg.wasm`). (#187)
- Update the baked-in beta CLI fallback version: `2.38.1-beta.02` → `2.39.0-beta.02`.

### Security

- Harden CI: add the StepSecurity harden-runner and pin GitHub Actions to commit SHAs across the E2E and fallback-version workflows, and restrict workflow permissions. (#182)